### PR TITLE
Updated links in CHANGELOG

### DIFF
--- a/.changeset/warm-items-accept.md
+++ b/.changeset/warm-items-accept.md
@@ -1,0 +1,5 @@
+---
+"analyze-ember-project-dependencies": patch
+---
+
+Updated links in CHANGELOG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,146 +10,146 @@
 
 ### Patch Changes
 
-- [#101](https://github.com/ijlee2/embroider-toolbox/pull/101) Installed @codemod-utils/package-json@v3 ([@ijlee2](https://github.com/ijlee2))
+- [#101](https://github.com/ijlee2/create-v2-addon-repo/pull/101) Installed @codemod-utils/package-json@v3 ([@ijlee2](https://github.com/ijlee2))
 
 ## 1.0.6
 
 ### Patch Changes
 
-- [#100](https://github.com/ijlee2/embroider-toolbox/pull/100) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#100](https://github.com/ijlee2/create-v2-addon-repo/pull/100) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 1.0.5
 
 ### Patch Changes
 
-- [#99](https://github.com/ijlee2/embroider-toolbox/pull/99) Updated @codemod-utils/ast-template-tag ([@ijlee2](https://github.com/ijlee2))
+- [#99](https://github.com/ijlee2/create-v2-addon-repo/pull/99) Updated @codemod-utils/ast-template-tag ([@ijlee2](https://github.com/ijlee2))
 
 ## 1.0.4
 
 ### Patch Changes
 
-- [#97](https://github.com/ijlee2/embroider-toolbox/pull/97) Replaced content-tag with @codemod-utils/ast-template-tag ([@ijlee2](https://github.com/ijlee2))
-- [#96](https://github.com/ijlee2/embroider-toolbox/pull/96) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#97](https://github.com/ijlee2/create-v2-addon-repo/pull/97) Replaced content-tag with @codemod-utils/ast-template-tag ([@ijlee2](https://github.com/ijlee2))
+- [#96](https://github.com/ijlee2/create-v2-addon-repo/pull/96) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 1.0.3
 
 ### Patch Changes
 
-- [#93](https://github.com/ijlee2/embroider-toolbox/pull/93) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#93](https://github.com/ijlee2/create-v2-addon-repo/pull/93) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 1.0.2
 
 ### Patch Changes
 
-- [#89](https://github.com/ijlee2/embroider-toolbox/pull/89) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
-- [#88](https://github.com/ijlee2/embroider-toolbox/pull/88) Separated formatting and linting ([@ijlee2](https://github.com/ijlee2))
+- [#89](https://github.com/ijlee2/create-v2-addon-repo/pull/89) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#88](https://github.com/ijlee2/create-v2-addon-repo/pull/88) Separated formatting and linting ([@ijlee2](https://github.com/ijlee2))
 
 ## 1.0.1
 
 ### Patch Changes
 
-- [#86](https://github.com/ijlee2/embroider-toolbox/pull/86) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#86](https://github.com/ijlee2/create-v2-addon-repo/pull/86) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 1.0.0
 
 ### Major Changes
 
-- [#84](https://github.com/ijlee2/embroider-toolbox/pull/84) Dropped Node 18 support ([@ijlee2](https://github.com/ijlee2))
+- [#84](https://github.com/ijlee2/create-v2-addon-repo/pull/84) Dropped Node 18 support ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.10
 
 ### Patch Changes
 
-- [#82](https://github.com/ijlee2/embroider-toolbox/pull/82) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#82](https://github.com/ijlee2/create-v2-addon-repo/pull/82) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.9
 
 ### Patch Changes
 
-- [#80](https://github.com/ijlee2/embroider-toolbox/pull/80) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#80](https://github.com/ijlee2/create-v2-addon-repo/pull/80) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.8
 
 ### Patch Changes
 
-- [#77](https://github.com/ijlee2/embroider-toolbox/pull/77) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#77](https://github.com/ijlee2/create-v2-addon-repo/pull/77) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.7
 
 ### Patch Changes
 
-- [#75](https://github.com/ijlee2/embroider-toolbox/pull/75) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#75](https://github.com/ijlee2/create-v2-addon-repo/pull/75) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.6
 
 ### Patch Changes
 
-- [#73](https://github.com/ijlee2/embroider-toolbox/pull/73) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
-- [#71](https://github.com/ijlee2/embroider-toolbox/pull/71) Simplified lint configurations ([@ijlee2](https://github.com/ijlee2))
-- [#70](https://github.com/ijlee2/embroider-toolbox/pull/70) Updated eslint to v9 ([@ijlee2](https://github.com/ijlee2))
-- [#69](https://github.com/ijlee2/embroider-toolbox/pull/69) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#73](https://github.com/ijlee2/create-v2-addon-repo/pull/73) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#71](https://github.com/ijlee2/create-v2-addon-repo/pull/71) Simplified lint configurations ([@ijlee2](https://github.com/ijlee2))
+- [#70](https://github.com/ijlee2/create-v2-addon-repo/pull/70) Updated eslint to v9 ([@ijlee2](https://github.com/ijlee2))
+- [#69](https://github.com/ijlee2/create-v2-addon-repo/pull/69) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.5
 
 ### Patch Changes
 
-- [#63](https://github.com/ijlee2/embroider-toolbox/pull/63) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#63](https://github.com/ijlee2/create-v2-addon-repo/pull/63) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.4
 
 ### Patch Changes
 
-- [#61](https://github.com/ijlee2/embroider-toolbox/pull/61) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#61](https://github.com/ijlee2/create-v2-addon-repo/pull/61) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.3
 
 ### Patch Changes
 
-- [#58](https://github.com/ijlee2/embroider-toolbox/pull/58) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#58](https://github.com/ijlee2/create-v2-addon-repo/pull/58) Updated dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.2
 
 ### Patch Changes
 
-- [#51](https://github.com/ijlee2/embroider-toolbox/pull/51) Updated typescript and @typescript-eslint/\* ([@ijlee2](https://github.com/ijlee2))
+- [#51](https://github.com/ijlee2/create-v2-addon-repo/pull/51) Updated typescript and @typescript-eslint/\* ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.1
 
 ### Patch Changes
 
-- [#46](https://github.com/ijlee2/embroider-toolbox/pull/46) Updated development dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#46](https://github.com/ijlee2/create-v2-addon-repo/pull/46) Updated development dependencies ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.4.0
 
 ### Minor Changes
 
-- [#32](https://github.com/ijlee2/embroider-toolbox/pull/32) Allowed specifying the component structure ([@ijlee2](https://github.com/ijlee2))
+- [#32](https://github.com/ijlee2/create-v2-addon-repo/pull/32) Allowed specifying the component structure ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.3.1
 
 ### Patch Changes
 
-- [#30](https://github.com/ijlee2/embroider-toolbox/pull/30) Downstreamed changes from @codemod-utils/cli@2.0.1 ([@ijlee2](https://github.com/ijlee2))
+- [#30](https://github.com/ijlee2/create-v2-addon-repo/pull/30) Downstreamed changes from @codemod-utils/cli@2.0.1 ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.3.0
 
 ### Minor Changes
 
-- [#28](https://github.com/ijlee2/embroider-toolbox/pull/28) Analyzed .gjs and .gts files ([@ijlee2](https://github.com/ijlee2))
+- [#28](https://github.com/ijlee2/create-v2-addon-repo/pull/28) Analyzed .gjs and .gts files ([@ijlee2](https://github.com/ijlee2))
 
 ### Patch Changes
 
-- [#29](https://github.com/ijlee2/embroider-toolbox/pull/29) Added README ([@ijlee2](https://github.com/ijlee2))
+- [#29](https://github.com/ijlee2/create-v2-addon-repo/pull/29) Added README ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.2.0
 
 ### Minor Changes
 
-- [#26](https://github.com/ijlee2/embroider-toolbox/pull/26) Analyzed entities and dependencies ([@ijlee2](https://github.com/ijlee2))
-- [#27](https://github.com/ijlee2/embroider-toolbox/pull/27) Found missing and unused dependencies. Optimized steps. ([@ijlee2](https://github.com/ijlee2))
+- [#26](https://github.com/ijlee2/create-v2-addon-repo/pull/26) Analyzed entities and dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#27](https://github.com/ijlee2/create-v2-addon-repo/pull/27) Found missing and unused dependencies. Optimized steps. ([@ijlee2](https://github.com/ijlee2))
 
 ## 0.1.0
 
 ### Minor Changes
 
-- [#20](https://github.com/ijlee2/embroider-toolbox/pull/20) Scaffolded analyze-ember-project-dependencies ([@ijlee2](https://github.com/ijlee2))
+- [#20](https://github.com/ijlee2/create-v2-addon-repo/pull/20) Scaffolded analyze-ember-project-dependencies ([@ijlee2](https://github.com/ijlee2))


### PR DESCRIPTION
## Background

After extracting `analyze-ember-project-dependencies`, I had renamed the `embroider-toolbox` repo to `create-v2-addon-repo`.
