### PR TITLE
Fixed lint errors

### DIFF
--- a/.changeset/beige-words-camp.md
+++ b/.changeset/beige-words-camp.md
@@ -1,0 +1,5 @@
+---
+"analyze-ember-project-dependencies": minor
+---
+
+Fixed lint errors

--- a/src/utils/find-dependencies/analyze-class/find-modules.ts
+++ b/src/utils/find-dependencies/analyze-class/find-modules.ts
@@ -45,16 +45,14 @@ export function findModules(file: string, data: Data): PackageAnalysis {
   const traverse = AST.traverse(isTypeScript);
 
   traverse(file, {
-    visitCallExpression(node) {
+    visitCallExpression(path) {
       let moduleName: string | undefined;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      switch (node.value.callee.type) {
+      switch (path.node.callee.type) {
         case 'Identifier': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          if (node.value.callee.name === 'require') {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            moduleName = node.value.arguments[0].value as string;
+          if (path.node.callee.name === 'require') {
+            // @ts-expect-error: Incorrect type
+            moduleName = path.node.arguments[0]!.value as string;
           }
 
           break;
@@ -62,13 +60,13 @@ export function findModules(file: string, data: Data): PackageAnalysis {
 
         case 'MemberExpression': {
           if (
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            node.value.callee.object.name === 'require' &&
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            node.value.callee.property.name === 'resolve'
+            // @ts-expect-error: Incorrect type
+            path.node.callee.object.name === 'require' &&
+            // @ts-expect-error: Incorrect type
+            path.node.callee.property.name === 'resolve'
           ) {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            moduleName = node.value.arguments[0].value as string;
+            // @ts-expect-error: Incorrect type
+            moduleName = path.node.arguments[0]!.value as string;
           }
 
           break;
@@ -88,14 +86,8 @@ export function findModules(file: string, data: Data): PackageAnalysis {
       return false;
     },
 
-    visitExportAllDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (node.value.source === null) {
-        return false;
-      }
-
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const moduleName = node.value.source.value as string;
+    visitExportAllDeclaration(path) {
+      const moduleName = path.node.source.value as string;
 
       if (ignore(moduleName)) {
         return false;
@@ -106,14 +98,12 @@ export function findModules(file: string, data: Data): PackageAnalysis {
       return false;
     },
 
-    visitExportNamedDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      if (node.value.source === null) {
+    visitExportNamedDeclaration(path) {
+      if (!path.node.source) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const moduleName = node.value.source.value as string;
+      const moduleName = path.node.source.value as string;
 
       if (ignore(moduleName)) {
         return false;
@@ -124,9 +114,8 @@ export function findModules(file: string, data: Data): PackageAnalysis {
       return false;
     },
 
-    visitImportDeclaration(node) {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      const moduleName = node.value.source.value as string;
+    visitImportDeclaration(path) {
+      const moduleName = path.node.source.value as string;
 
       if (ignore(moduleName)) {
         return false;

--- a/src/utils/find-dependencies/analyze-class/find-modules.ts
+++ b/src/utils/find-dependencies/analyze-class/find-modules.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { AST } from '@codemod-utils/ast-javascript';
 
 import type { PackageAnalysis } from '../../../types/index.js';
@@ -49,9 +48,12 @@ export function findModules(file: string, data: Data): PackageAnalysis {
     visitCallExpression(node) {
       let moduleName: string | undefined;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (node.value.callee.type) {
         case 'Identifier': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (node.value.callee.name === 'require') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             moduleName = node.value.arguments[0].value as string;
           }
 
@@ -60,9 +62,12 @@ export function findModules(file: string, data: Data): PackageAnalysis {
 
         case 'MemberExpression': {
           if (
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             node.value.callee.object.name === 'require' &&
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             node.value.callee.property.name === 'resolve'
           ) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             moduleName = node.value.arguments[0].value as string;
           }
 
@@ -84,10 +89,12 @@ export function findModules(file: string, data: Data): PackageAnalysis {
     },
 
     visitExportAllDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (node.value.source === null) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const moduleName = node.value.source.value as string;
 
       if (ignore(moduleName)) {
@@ -100,10 +107,12 @@ export function findModules(file: string, data: Data): PackageAnalysis {
     },
 
     visitExportNamedDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (node.value.source === null) {
         return false;
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const moduleName = node.value.source.value as string;
 
       if (ignore(moduleName)) {
@@ -116,6 +125,7 @@ export function findModules(file: string, data: Data): PackageAnalysis {
     },
 
     visitImportDeclaration(node) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       const moduleName = node.value.source.value as string;
 
       if (ignore(moduleName)) {

--- a/src/utils/find-dependencies/analyze-class/find-services.ts
+++ b/src/utils/find-dependencies/analyze-class/find-services.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { AST } from '@codemod-utils/ast-javascript';
 
 import type { PackageAnalysis } from '../../../types/index.js';
@@ -20,19 +19,24 @@ export function findServices(file: string, data: Data): PackageAnalysis {
   traverse(file, {
     visitClassProperty(node) {
       if (
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         !Array.isArray(node.value.decorators) ||
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
         node.value.decorators.length !== 1
       ) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
       const decorator = node.value.decorators[0];
       let serviceName: string | undefined;
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (decorator.expression.type) {
         case 'CallExpression': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (decorator.expression.callee.name == 'service') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             serviceName = decorator.expression.arguments[0].value as string;
           }
 
@@ -40,7 +44,9 @@ export function findServices(file: string, data: Data): PackageAnalysis {
         }
 
         case 'Identifier': {
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (decorator.expression.name === 'service') {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
             serviceName = dasherize(node.value.key.name as string);
           }
 

--- a/src/utils/find-dependencies/analyze-class/find-services.ts
+++ b/src/utils/find-dependencies/analyze-class/find-services.ts
@@ -3,6 +3,8 @@ import { AST } from '@codemod-utils/ast-javascript';
 import type { PackageAnalysis } from '../../../types/index.js';
 import type { Data } from '../index.js';
 
+type Decorator = ReturnType<typeof AST.builders.decorator>;
+
 function dasherize(value: string): string {
   return value.replace(/([a-z\d])([A-Z])/g, '$1-$2').toLowerCase();
 }
@@ -17,37 +19,34 @@ export function findServices(file: string, data: Data): PackageAnalysis {
   const traverse = AST.traverse(isTypeScript);
 
   traverse(file, {
-    visitClassProperty(node) {
-      if (
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        !Array.isArray(node.value.decorators) ||
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        node.value.decorators.length !== 1
-      ) {
+    visitClassProperty(path) {
+      // @ts-expect-error: Incorrect type
+      const decorators = path.node.decorators as Decorator[];
+
+      if (!Array.isArray(decorators) || decorators.length !== 1) {
         return false;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-      const decorator = node.value.decorators[0];
+      const decorator = decorators[0]!;
       let serviceName: string | undefined;
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       switch (decorator.expression.type) {
         case 'CallExpression': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-          if (decorator.expression.callee.name == 'service') {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            serviceName = decorator.expression.arguments[0].value as string;
+          if (
+            decorator.expression.callee.type === 'Identifier' &&
+            decorator.expression.callee.name === 'service'
+          ) {
+            // @ts-expect-error: Incorrect type
+            serviceName = decorator.expression.arguments[0]!.value as string;
           }
 
           break;
         }
 
         case 'Identifier': {
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
           if (decorator.expression.name === 'service') {
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-            serviceName = dasherize(node.value.key.name as string);
+            // @ts-expect-error: Incorrect type
+            serviceName = dasherize(path.node.key.name as string);
           }
 
           break;


### PR DESCRIPTION
## Background

Incorrect use of `recast` had led to unnecessary type errors. In general, `node.value` should have read `path.node` instead.
